### PR TITLE
Use ceil for read time

### DIFF
--- a/main-blog-grid.liquid
+++ b/main-blog-grid.liquid
@@ -88,7 +88,7 @@
                 <div class="hero__meta">
                   <time datetime="{{ hero.published_at | date: "%Y-%m-%d" }}">{{ hero.published_at | date: format: "date" }}</time>
                   {% assign words = hero.content | strip_html | split: ' ' | size %}
-                  {% assign minutes = words | divided_by: 200 %}{% if minutes < 1 %}{% assign minutes = 1 %}{% endif %}
+                  {% assign minutes = words | divided_by: 200 | ceil %}
                   <span class="dot">•</span><span>{{ minutes }} min read</span>
                 </div>
                 {% assign preview_h = hero.excerpt_or_content | strip_html | truncate: 120, '…' %}
@@ -154,7 +154,7 @@
                       {% endif %}
                       {% if section.settings.show_read_time %}
                         {% assign words = article.content | strip_html | split: ' ' | size %}
-                        {% assign minutes = words | divided_by: 200 %}{% if minutes < 1 %}{% assign minutes = 1 %}{% endif %}
+                        {% assign minutes = words | divided_by: 200 | ceil %}
                         <span class="dot">•</span><span>{{ minutes }} min read</span>
                       {% endif %}
                     </div>


### PR DESCRIPTION
## Summary
- calculate read time using `ceil` for hero and list sections
- remove obsolete guard clause for minimum minute

## Testing
- `ruby test_read_time.rb`


------
https://chatgpt.com/codex/tasks/task_e_68b2e79bdfd88325ab53f3b01287a3f5